### PR TITLE
fix usage of setsid

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for MooseX-Daemonize
 
 {{$NEXT}}
+    - fix usage of setsid
 
 0.21      2016-02-16 05:15:14Z
     - some distribution retooling

--- a/lib/MooseX/Daemonize/Core.pm
+++ b/lib/MooseX/Daemonize/Core.pm
@@ -76,8 +76,8 @@ sub daemon_detach {
     $self->_get_options( %options );
     # now we are in the daemon ...
 
-    (POSIX::setsid)  # set session id
-        || confess "Cannot detach from controlling process";
+    POSIX::setsid == -1  # set session id
+        and confess "Cannot detach from controlling process";
 
     unless ( $self->no_double_fork ) {
         $SIG{'HUP'} = 'IGNORE';


### PR DESCRIPTION
POSIX::setsid returns -1, not undef on failure:
```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid; print "$ret: $!"'
-1: Operation not permitted
```